### PR TITLE
Set default 'maxDeliveryCount' for queues and subscriptions to 3

### DIFF
--- a/src/servicebus/Queue.fs
+++ b/src/servicebus/Queue.fs
@@ -46,7 +46,7 @@ module Queue =
                                                         // 5 minutes; the default value is 1 minute.
         maxDeliveryCount: int                           // The maximum delivery count. A message is
                                                         // automatically deadlettered after this number of
-                                                        // deliveries. default value is 10
+                                                        // deliveries. default value is 3
         maxSize: MaxSize                                // The maximum size of queue in megabytes, which is
                                                         // the size of memory allocated for the queue.
                                                         // Default is 1024
@@ -74,7 +74,7 @@ module Queue =
         forwardDeadLetteredMessagesTo = ""
         forwardTo = ""
         lockDuration = minutes 1
-        maxDeliveryCount = 10
+        maxDeliveryCount = 3
         maxSize = MB_1024
         status = Active
     }

--- a/src/servicebus/Subscription.fs
+++ b/src/servicebus/Subscription.fs
@@ -33,7 +33,7 @@ module Subscription =
         lockDuration: TimeSpan
                             // lock duration for the subscription. The default value is 1 minute.        
         maxDeliveryCount: int
-                            // Number of maximum deliveries.
+                            // Number of maximum deliveries. Default value is 3.
         requiresSession: bool
                             // Value indicating if a subscription supports the concept of sessions.                                                   
     }
@@ -48,7 +48,7 @@ module Subscription =
         forwardDeadLetteredMessagesTo = None
         forwardTo = None
         lockDuration = TimeSpan (0, 1, 0)     
-        maxDeliveryCount = 10
+        maxDeliveryCount = 3
         requiresSession = false
     }
 


### PR DESCRIPTION
Det gir ikke mye mening å forsøke 10 ganger så lenge man ikke har en eksponentiell retry-policy. Det skaper bare ekstra mye støy i loggene. 